### PR TITLE
Fixed incorrect detection of fully connected peers for sending consensus messages

### DIFF
--- a/crates/ethcore/sync/src/api.rs
+++ b/crates/ethcore/sync/src/api.rs
@@ -465,8 +465,10 @@ impl SyncProtocolHandler {
         for node_id in pub_keys.iter() {
             if let Some(peer_id) = nc.node_id_to_peer_id(*node_id) {
                 let found_peers = self.sync.peer_info(&[peer_id]);
-                if let Some(_) = found_peers.first() {
-                    self.send_cached_consensus_messages_for(&mut sync_io, node_id, peer_id);
+                if let Some(peer_info) = found_peers.first() {
+                    if let Some(peer_info) = peer_info {
+                        self.send_cached_consensus_messages_for(&mut sync_io, node_id, peer_id);
+                    }
                 }
             }
         }

--- a/crates/ethcore/sync/src/api.rs
+++ b/crates/ethcore/sync/src/api.rs
@@ -466,7 +466,7 @@ impl SyncProtocolHandler {
             if let Some(peer_id) = nc.node_id_to_peer_id(*node_id) {
                 let found_peers = self.sync.peer_info(&[peer_id]);
                 if let Some(peer_info) = found_peers.first() {
-                    if let Some(peer_info) = peer_info {
+                    if let Some(_) = peer_info {
                         self.send_cached_consensus_messages_for(&mut sync_io, node_id, peer_id);
                     }
                 }


### PR DESCRIPTION
Consensus messages could get lost because connection detection was faulty. This could lead to attempts to send consensus messages to a peer which was not connected at all!