### PR TITLE
key gen round counter

### DIFF
--- a/crates/ethcore/res/contracts/key_history_contract.json
+++ b/crates/ethcore/res/contracts/key_history_contract.json
@@ -41,6 +41,21 @@
 	{
 		"constant": true,
 		"inputs": [],
+		"name": "currentKeyGenRound",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
 		"name": "numberOfAcksWritten",
 		"outputs": [
 			{
@@ -83,27 +98,6 @@
 				"internalType": "bytes",
 				"name": "",
 				"type": "bytes"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"internalType": "uint256",
-				"name": "",
-				"type": "uint256"
-			}
-		],
-		"name": "validatorSet",
-		"outputs": [
-			{
-				"internalType": "address",
-				"name": "",
-				"type": "address"
 			}
 		],
 		"payable": false,
@@ -174,9 +168,14 @@
 		"constant": false,
 		"inputs": [
 			{
-				"internalType": "uint256",
+				"internalType": "uint32",
 				"name": "_upcommingEpoch",
-				"type": "uint256"
+				"type": "uint32"
+			},
+			{
+				"internalType": "uint32",
+				"name": "_roundCounter",
+				"type": "uint32"
 			},
 			{
 				"internalType": "bytes",
@@ -194,9 +193,14 @@
 		"constant": false,
 		"inputs": [
 			{
-				"internalType": "uint256",
+				"internalType": "uint32",
 				"name": "_upcommingEpoch",
-				"type": "uint256"
+				"type": "uint32"
+			},
+			{
+				"internalType": "uint32",
+				"name": "_roundCounter",
+				"type": "uint32"
 			},
 			{
 				"internalType": "bytes[]",

--- a/crates/ethcore/res/contracts/key_history_contract.json
+++ b/crates/ethcore/res/contracts/key_history_contract.json
@@ -136,6 +136,24 @@
 	},
 	{
 		"constant": false,
+		"inputs": [],
+		"name": "notifyKeyGenFailed",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "notifyNewEpoch",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
 		"inputs": [
 			{
 				"internalType": "address",
@@ -168,14 +186,14 @@
 		"constant": false,
 		"inputs": [
 			{
-				"internalType": "uint32",
+				"internalType": "uint256",
 				"name": "_upcommingEpoch",
-				"type": "uint32"
+				"type": "uint256"
 			},
 			{
-				"internalType": "uint32",
+				"internalType": "uint256",
 				"name": "_roundCounter",
-				"type": "uint32"
+				"type": "uint256"
 			},
 			{
 				"internalType": "bytes",
@@ -193,14 +211,14 @@
 		"constant": false,
 		"inputs": [
 			{
-				"internalType": "uint32",
+				"internalType": "uint256",
 				"name": "_upcommingEpoch",
-				"type": "uint32"
+				"type": "uint256"
 			},
 			{
-				"internalType": "uint32",
+				"internalType": "uint256",
 				"name": "_roundCounter",
-				"type": "uint32"
+				"type": "uint256"
 			},
 			{
 				"internalType": "bytes[]",
@@ -245,6 +263,21 @@
 			}
 		],
 		"name": "getAcksLength",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "getCurrentKeyGenRound",
 		"outputs": [
 			{
 				"internalType": "uint256",

--- a/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
+++ b/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
@@ -121,7 +121,7 @@ pub fn get_current_key_gen_round(client: &dyn EngineClient)  -> Result<U256, Cal
 	//Ok(serialized_result.low_u64() != 0)
 	//Ok(serialized_length.low_u64() != 0)
 
-	Ok(U256::from(0))
+	Ok(U256::from(serialized_result))
 
 }
 

--- a/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
+++ b/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
@@ -8,7 +8,7 @@ use engines::{
     },
     signer::EngineSigner,
 };
-use ethereum_types::{Address, H512};
+use ethereum_types::{Address, H512, U256};
 use hbbft::{
     crypto::{PublicKeySet, SecretKeyShare},
     sync_key_gen::{
@@ -110,6 +110,22 @@ pub fn part_of_address(
         PartOutcome::Valid(ack) => Ok(ack),
     }
 }
+
+pub fn get_current_key_gen_round(client: &dyn EngineClient)  -> Result<U256, CallError> {
+	// let c = BoundContract::bind(client, block_id, *STAKING_CONTRACT_ADDRESS);
+	// call_const_staking!(c, staking_epoch)
+
+	let c = BoundContract::bind(client, BlockId::Latest, *KEYGEN_HISTORY_ADDRESS);
+	let serialized_result = call_const_key_history!(c, get_current_key_gen_round)?;
+
+	//Ok(serialized_result.low_u64() != 0)
+	//Ok(serialized_length.low_u64() != 0)
+
+	Ok(U256::from(0))
+
+}
+
+
 
 pub fn has_acks_of_address_data(
     client: &dyn EngineClient,

--- a/crates/ethcore/src/engines/hbbft/keygen_transactions.rs
+++ b/crates/ethcore/src/engines/hbbft/keygen_transactions.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use std::{collections::BTreeMap, sync::Arc};
 use types::ids::BlockId;
+use engines::hbbft::contracts::keygen_history::get_current_key_gen_round;
 
 pub struct KeygenTransactionSender {
     last_keygen_mode: KeyGenMode,
@@ -137,8 +138,9 @@ impl KeygenTransactionSender {
                 Err(_) => return Err(CallError::ReturnValueInvalid),
             };
             let serialized_part_len = serialized_part.len();
+			let current_round = get_current_key_gen_round(client)?;
             let write_part_data =
-                key_history_contract::functions::write_part::call(upcoming_epoch, serialized_part);
+                key_history_contract::functions::write_part::call(upcoming_epoch,  current_round, serialized_part);
 
             // the required gas values have been approximated by
             // experimenting and it's a very rough estimation.
@@ -197,9 +199,9 @@ impl KeygenTransactionSender {
                 total_bytes_for_acks += ack_to_push.len();
                 serialized_acks.push(ack_to_push);
             }
-
+			let current_round = get_current_key_gen_round(client)?;
             let write_acks_data =
-                key_history_contract::functions::write_acks::call(upcoming_epoch, serialized_acks);
+                key_history_contract::functions::write_acks::call(upcoming_epoch, current_round, serialized_acks);
 
             // the required gas values have been approximated by
             // experimenting and it's a very rough estimation.


### PR DESCRIPTION
This update makes the software compatible to the contract update for the new key gen round counter: 
https://github.com/DMDcoin/openethereum-3.x/issues/46
Contracts updates:
https://github.com/DMDcoin/hbbft-posdao-contracts/pull/108