### PR TITLE
skipping block reward calls possibility

### DIFF
--- a/crates/ethcore/src/engines/hbbft/contracts/validator_set.rs
+++ b/crates/ethcore/src/engines/hbbft/contracts/validator_set.rs
@@ -5,7 +5,6 @@ use client::{
 use crypto::publickey::Public;
 use engines::hbbft::utils::bound_contract::{BoundContract, CallError};
 use ethereum_types::{Address, U256};
-use ethjson::types::hash::H256;
 use std::{collections::BTreeMap, str::FromStr};
 use types::{ids::BlockId, transaction::Error};
 

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -940,9 +940,9 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
             let _total_reward = contract.reward(&mut call, is_epoch_end)?;
         }
 
-		self.hbbft_message_memorial
-			.write()
-			.free_memory(block.header.number());
+        self.hbbft_message_memorial
+            .write()
+            .free_memory(block.header.number());
 
         Ok(())
     }

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -939,6 +939,11 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
             let contract = BlockRewardContract::new_from_address(address);
             let _total_reward = contract.reward(&mut call, is_epoch_end)?;
         }
+
+		self.hbbft_message_memorial
+			.write()
+			.free_memory(block.header.number());
+
         Ok(())
     }
 }

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -931,13 +931,21 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 
     fn on_close_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
         self.check_for_epoch_change();
+
         if let Some(address) = self.params.block_reward_contract_address {
+            // only if no block reward skips are defined for this block.
             let header_number = block.header.number();
-            let mut call = default_system_or_code_call(&self.machine, block);
-            let is_epoch_end = self.do_keygen();
-            trace!(target: "consensus", "calling reward function for block {} isEpochEnd? {} on address: {}", header_number,  is_epoch_end, address);
-            let contract = BlockRewardContract::new_from_address(address);
-            let _total_reward = contract.reward(&mut call, is_epoch_end)?;
+
+            if self
+                .params
+                .should_do_block_reward_contract_call(header_number)
+            {
+                let mut call = default_system_or_code_call(&self.machine, block);
+                let is_epoch_end = self.do_keygen();
+                trace!(target: "consensus", "calling reward function for block {} isEpochEnd? {} on address: {}", header_number,  is_epoch_end, address);
+                let contract = BlockRewardContract::new_from_address(address);
+                let _total_reward = contract.reward(&mut call, is_epoch_end)?;
+            }
         }
 
         self.hbbft_message_memorial

--- a/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
@@ -180,7 +180,6 @@ impl HbbftMessageMemorium {
         // todo: also remember sealing messages in an organized way
     }
 
-
     pub fn free_memory(&mut self, _current_block: u64) {
         // self.signature_shares.remove(&epoch);
     }

--- a/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
@@ -179,7 +179,9 @@ impl HbbftMessageMemorium {
 
         // todo: also remember sealing messages in an organized way
     }
-    pub fn free_epoch_memory(&mut self, _epoch: u64) {
+
+
+    pub fn free_memory(&mut self, _current_block: u64) {
         // self.signature_shares.remove(&epoch);
     }
 }

--- a/crates/ethcore/src/engines/hbbft/test/mod.rs
+++ b/crates/ethcore/src/engines/hbbft/test/mod.rs
@@ -119,14 +119,14 @@ fn test_epoch_transition() {
     let transactor: KeyPair = Random.generate();
 
     let genesis_transition_time = start_time_of_next_phase_transition(moc.client.as_ref())
-        .expect("Constant call must succeed");
+        .expect("start_time_of_next_phase_transition call must succeed");
 
     // Genesis block is at time 0, current unix time must be much larger.
     assert!(genesis_transition_time.as_u64() < unix_now_secs());
 
     // We should not be in the pending validator set at the genesis block.
     assert!(!is_pending_validator(moc.client.as_ref(), &moc.address())
-        .expect("Constant call must succeed"));
+        .expect("is_pending_validator call must succeed"));
 
     // Fund the transactor.
     // Also triggers the creation of a block.

--- a/crates/ethcore/sync/src/chain/handler.rs
+++ b/crates/ethcore/sync/src/chain/handler.rs
@@ -42,7 +42,6 @@ use super::{
     SyncState, ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64, ETH_PROTOCOL_VERSION_65,
     MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES, PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_2,
 };
-use ethcore::error::TransactionImportError::Other;
 use network::client_version::ClientCapabilities;
 
 /// The Chain Sync Handler: handles responses from peers

--- a/crates/ethjson/src/spec/hbbft.rs
+++ b/crates/ethjson/src/spec/hbbft.rs
@@ -17,7 +17,6 @@
 //! Hbbft parameter deserialization.
 
 use ethereum_types::Address;
-use serde::Deserialize;
 
 /// Hbbft parameters.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -34,6 +33,8 @@ pub struct HbbftParams {
     pub is_unit_test: Option<bool>,
     /// Block reward contract address.
     pub block_reward_contract_address: Option<Address>,
+
+
 }
 
 /// Hbbft engine config.

--- a/crates/ethjson/src/spec/step_duration.rs
+++ b/crates/ethjson/src/spec/step_duration.rs
@@ -18,8 +18,6 @@
 
 use std::collections::BTreeMap;
 
-use serde::Deserialize;
-
 use crate::uint::Uint;
 
 /// Step duration can be specified either as a `Uint` (in seconds), in which case it will be

--- a/crates/net/network/src/client_version.rs
+++ b/crates/net/network/src/client_version.rs
@@ -72,6 +72,7 @@ impl ParityClientData {
         }
     }
 
+    /// gets name
     pub fn name(&self) -> &str {
         self.name.as_str()
     }

--- a/crates/util/EIP-712/src/eip712.rs
+++ b/crates/util/EIP-712/src/eip712.rs
@@ -30,9 +30,9 @@ lazy_static! {
     static ref IDENT_REGEX: Regex = Regex::new(r"^[a-zA-Z_$][a-zA-Z_$0-9]*$").unwrap();
 }
 
+#[derive(Deserialize, Serialize, Validate, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
-#[derive(Deserialize, Serialize, Validate, Debug, Clone)]
 pub(crate) struct EIP712Domain {
     pub(crate) name: String,
     pub(crate) version: String,
@@ -42,9 +42,9 @@ pub(crate) struct EIP712Domain {
     pub(crate) salt: Option<H256>,
 }
 /// EIP-712 struct
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
-#[derive(Deserialize, Debug, Clone)]
 pub struct EIP712 {
     pub(crate) types: MessageTypes,
     pub(crate) primary_type: String,


### PR DESCRIPTION
This change allows the hbbft engine to skip block reward calls for a defined range in the chain spec.
This can be used in scenarios where a bad contract update made the network inoperatable.

more about: 
https://github.com/DMDcoin/openethereum-3.x/issues/49

skipped block reward calls can now be configured in the hbbft engine config section:

```
"blockRewardSkips" : [
    { "fromBlock": 1000, "toBlock": 2000 },
    { "fromBlock": 3000 }
]
```