### PR TITLE
Potential fix for 0-tx blocks.

### DIFF
--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -3084,7 +3084,7 @@ impl super::traits::EngineClient for Client {
     }
 
     fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
-        self.importer.miner.queued_transactions()
+        self.importer.miner.queued_transactions(self)
     }
 
     fn create_pending_block_at(

--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -1173,7 +1173,7 @@ impl super::traits::EngineClient for TestBlockChainClient {
     }
 
     fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
-        self.miner.queued_transactions()
+        self.miner.queued_transactions(self)
     }
 
     fn create_pending_block_at(

--- a/crates/ethcore/src/engines/hbbft/test/hbbft_test_client.rs
+++ b/crates/ethcore/src/engines/hbbft/test/hbbft_test_client.rs
@@ -116,7 +116,7 @@ impl HbbftTestClient {
     pub fn sync_transactions_to(&self, other: &mut Self) {
         let transactions = self
             .miner
-            .queued_transactions()
+            .all_transactions()
             //.transactions_to_propagate()
             .iter()
             .map(|i| i.signed().deref().clone())

--- a/crates/ethcore/src/miner/mod.rs
+++ b/crates/ethcore/src/miner/mod.rs
@@ -243,7 +243,9 @@ pub trait MinerService: Send + Sync {
     }
 
     /// Get a list of all transactions in the pool (some of them might not be ready for inclusion yet).
-    fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>>;
+    fn queued_transactions<C>(&self, chain: &C) -> Vec<Arc<VerifiedTransaction>>
+    where
+        C: BlockChain + CallContract + Nonce + Sync;
 
     /// Get a list of all transaction hashes in the pool (some of them might not be ready for inclusion yet).
     fn queued_transaction_hashes(&self) -> Vec<H256>;


### PR DESCRIPTION
Using only pending transactions for the current block rather than all transactions from the transaction queue.