### PR TITLE
fix for  Key Gen Transactions not broadcasted (81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Diamond Node Software ## 3.3.4-hbbft-0.9.0
+## Diamond Node Software ## 3.3.4-hbbft-0.8.2
 
 Merge with OpenEthereum 3.3.4.
 
+## Diamond Node Software ## 3.2.5-hbbft-0.8.1
 Performance and stability improvement for active validator nodes.
 
 *  [Multithreading for hbbft message analysis and logging](https://github.com/DMDcoin/openethereum-3.x/issues/76)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openethereum"
-version = "3.3.4-hbbft-0.9.0"
+version = "3.3.4-hbbft-0.8.2"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "OpenEthereum"
 name = "openethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "3.3.4-hbbft-0.9.0"
+version = "3.3.4-hbbft-0.8.2"
 license = "GPL-3.0"
 authors = [
 	"OpenEthereum developers",

--- a/crates/concensus/miner/src/pool/mod.rs
+++ b/crates/concensus/miner/src/pool/mod.rs
@@ -109,10 +109,10 @@ pub enum Priority {
     /// Transactions either from a local account or
     /// submitted over local RPC connection via `eth_sendRawTransaction`
     Local,
-	/// Service Transaction (high prioritiy)
-	///
-	/// Service transaction entering the pool from gossiping from other Nodes.
-	Service
+    /// Service Transaction (high prioritiy)
+    ///
+    /// Service transaction entering the pool from gossiping from other Nodes.
+    Service,
 }
 
 impl Priority {
@@ -123,12 +123,12 @@ impl Priority {
         }
     }
 
-	fn is_service(&self) -> bool {
-		match *self {
-			Priority::Service => true,
-			_ => false,
-		}
-	}
+    fn is_service(&self) -> bool {
+        match *self {
+            Priority::Service => true,
+            _ => false,
+        }
+    }
 }
 
 /// Scoring properties for verified transaction.

--- a/crates/concensus/miner/src/pool/mod.rs
+++ b/crates/concensus/miner/src/pool/mod.rs
@@ -109,6 +109,10 @@ pub enum Priority {
     /// Transactions either from a local account or
     /// submitted over local RPC connection via `eth_sendRawTransaction`
     Local,
+	/// Service Transaction (high prioritiy)
+	///
+	/// Service transaction entering the pool from gossiping from other Nodes.
+	Service
 }
 
 impl Priority {
@@ -118,6 +122,13 @@ impl Priority {
             _ => false,
         }
     }
+
+	fn is_service(&self) -> bool {
+		match *self {
+			Priority::Service => true,
+			_ => false,
+		}
+	}
 }
 
 /// Scoring properties for verified transaction.

--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -359,6 +359,8 @@ impl TransactionQueue {
                 let imported = verifier
                     .verify_transaction(transaction)
                     .and_then(|verified| {
+						let status = self.pool.read().light_status();
+						debug!(target: "txqueue", "importing pool status: {:?}", status);
                         self.pool.write().import(verified, &mut replace).map_err(convert_error)
                     });
 

--- a/crates/concensus/miner/src/pool/scoring.rs
+++ b/crates/concensus/miner/src/pool/scoring.rs
@@ -128,7 +128,7 @@ where
                 scores[i] = txs[i].effective_gas_price(self.block_base_fee);
                 let boost = match txs[i].priority() {
                     super::Priority::Local => 15,
-					super::Priority::Service => 14,
+                    super::Priority::Service => 14,
                     super::Priority::Retracted => 10,
                     super::Priority::Regular => 0,
                 };
@@ -155,7 +155,7 @@ where
                             scores[i] = txs[i].transaction.effective_gas_price(self.block_base_fee);
                             let boost = match txs[i].priority() {
                                 super::Priority::Local => 15,
-								super::Priority::Service => 14,
+                                super::Priority::Service => 14,
                                 super::Priority::Retracted => 10,
                                 super::Priority::Regular => 0,
                             };

--- a/crates/concensus/miner/src/pool/scoring.rs
+++ b/crates/concensus/miner/src/pool/scoring.rs
@@ -128,6 +128,7 @@ where
                 scores[i] = txs[i].effective_gas_price(self.block_base_fee);
                 let boost = match txs[i].priority() {
                     super::Priority::Local => 15,
+					super::Priority::Service => 14,
                     super::Priority::Retracted => 10,
                     super::Priority::Regular => 0,
                 };
@@ -154,6 +155,7 @@ where
                             scores[i] = txs[i].transaction.effective_gas_price(self.block_base_fee);
                             let boost = match txs[i].priority() {
                                 super::Priority::Local => 15,
+								super::Priority::Service => 14,
                                 super::Priority::Retracted => 10,
                                 super::Priority::Regular => 0,
                             };
@@ -172,7 +174,7 @@ where
     }
 
     fn should_ignore_sender_limit(&self, new: &P) -> bool {
-        new.priority().is_local()
+        new.priority().is_local() || new.priority().is_service()
     }
 }
 

--- a/crates/concensus/miner/src/pool/verifier.rs
+++ b/crates/concensus/miner/src/pool/verifier.rs
@@ -330,7 +330,7 @@ impl<C: Client> txpool::Verifier<Transaction>
 
         let sender = transaction.sender();
         let account_details = self.client.account_details(&sender);
-		let mut is_service_tx = false;
+        let mut is_service_tx = false;
         if !self.options.allow_non_eoa_sender {
             if let Some(code_hash) = account_details.code_hash {
                 if code_hash != KECCAK_EMPTY {
@@ -351,7 +351,7 @@ impl<C: Client> txpool::Verifier<Transaction>
             let transaction_type = self.client.transaction_type(&transaction);
             if let TransactionType::Service = transaction_type {
                 debug!(target: "txqueue", "Service tx {:?} below minimal gas price accepted", hash);
-				is_service_tx = true;
+                is_service_tx = true;
             } else if is_own || account_details.is_local {
                 info!(target: "own_tx", "Local tx {:?} below minimal gas price accepted", hash);
             } else {
@@ -416,18 +416,22 @@ impl<C: Client> txpool::Verifier<Transaction>
             bail!(transaction::Error::Old);
         }
 
-		let priority = match (is_own || account_details.is_local, is_service_tx, is_retracted) {
-			(true, _, _) => super::Priority::Local,
-			(false, true, _) => super::Priority::Service,
-			(false, false, false) => super::Priority::Regular,
-			(false, _, true) => super::Priority::Retracted,
-		};
-		debug!(
-                target: "txqueue",
-                "[{:?}] priority: {:?}",
-                hash,
-                priority
-            );
+        let priority = match (
+            is_own || account_details.is_local,
+            is_service_tx,
+            is_retracted,
+        ) {
+            (true, _, _) => super::Priority::Local,
+            (false, true, _) => super::Priority::Service,
+            (false, false, false) => super::Priority::Regular,
+            (false, _, true) => super::Priority::Retracted,
+        };
+        debug!(
+            target: "txqueue",
+            "[{:?}] priority: {:?}",
+            hash,
+            priority
+        );
         Ok(VerifiedTransaction {
             transaction,
             priority,

--- a/crates/concensus/miner/src/pool/verifier.rs
+++ b/crates/concensus/miner/src/pool/verifier.rs
@@ -330,7 +330,7 @@ impl<C: Client> txpool::Verifier<Transaction>
 
         let sender = transaction.sender();
         let account_details = self.client.account_details(&sender);
-
+		let mut is_service_tx = false;
         if !self.options.allow_non_eoa_sender {
             if let Some(code_hash) = account_details.code_hash {
                 if code_hash != KECCAK_EMPTY {
@@ -351,6 +351,7 @@ impl<C: Client> txpool::Verifier<Transaction>
             let transaction_type = self.client.transaction_type(&transaction);
             if let TransactionType::Service = transaction_type {
                 debug!(target: "txqueue", "Service tx {:?} below minimal gas price accepted", hash);
+				is_service_tx = true;
             } else if is_own || account_details.is_local {
                 info!(target: "own_tx", "Local tx {:?} below minimal gas price accepted", hash);
             } else {
@@ -415,11 +416,18 @@ impl<C: Client> txpool::Verifier<Transaction>
             bail!(transaction::Error::Old);
         }
 
-        let priority = match (is_own || account_details.is_local, is_retracted) {
-            (true, _) => super::Priority::Local,
-            (false, false) => super::Priority::Regular,
-            (false, true) => super::Priority::Retracted,
-        };
+		let priority = match (is_own || account_details.is_local, is_service_tx, is_retracted) {
+			(true, _, _) => super::Priority::Local,
+			(false, true, _) => super::Priority::Service,
+			(false, false, false) => super::Priority::Regular,
+			(false, _, true) => super::Priority::Retracted,
+		};
+		debug!(
+                target: "txqueue",
+                "[{:?}] priority: {:?}",
+                hash,
+                priority
+            );
         Ok(VerifiedTransaction {
             transaction,
             priority,

--- a/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
+++ b/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
@@ -236,19 +236,12 @@ pub fn initialize_synckeygen(
     let (mut synckeygen, _) = engine_signer_to_synckeygen(signer, Arc::new(pub_keys))
         .map_err(|_| CallError::ReturnValueInvalid)?;
 
-    let mut num_of_parts = 0;
-    let mut num_of_acks = 0;
-
     for v in vmap.keys().sorted() {
         part_of_address(&*client, *v, &vmap, &mut synckeygen, block_id)?;
-        num_of_parts = num_of_parts + 1;
     }
     for v in vmap.keys().sorted() {
         acks_of_address(&*client, *v, &vmap, &mut synckeygen, block_id)?;
-        num_of_acks = num_of_acks + 1;
     }
-
-    info!(target: "engine", "initialize_synckeygen ok with parts: {} acks: {}", num_of_parts, num_of_acks);
 
     Ok(synckeygen)
 }


### PR DESCRIPTION
https://github.com/DMDcoin/openethereum-3.x/issues/81

introduced new message service transaction support in the message queue for gossiped transactions.
Without that fix, the transactions were kind of accepted by the engine, but rejected by the transaction queue.

example:
```
2022-04-01 10:29:53  Worker Client3 DEBUG txqueue  Service tx 0xec11a4a698cdfb58b38dd8634d5e6895f2e6952558b19935203455b3a9f2303b below minimal gas price accepted
2022-04-01 10:29:53  Worker Client3 TRACE txqueue  Rejected [ec11a4a698cdfb58b38dd8634d5e6895f2e6952558b19935203455b3a9f2303b] too cheap to enter the pool. Min score: 0x0.
```