### PR TITLE
staging implementation for configurability of consensus memorial

### DIFF
--- a/bin/oe/cli/mod.rs
+++ b/bin/oe/cli/mod.rs
@@ -814,6 +814,12 @@ usage! {
             ARG arg_snapshot_threads: (Option<usize>) = None, or |c: &Config| c.snapshots.as_ref()?.processing_threads,
             "--snapshot-threads=[NUM]",
             "Enables multiple threads for snapshots creation.",
+
+        ["Hbbft Options "]
+            ARG blocks_to_keep_on_disk: (Option<u64>) = Some(0), or |c: &Config| c.hbbft.as_ref()?.blocks_to_keep_on_disk,
+            "--blocks-to-keep-on-disk=[NUM]",
+            "Configures hbbft messages that should be kept on disk. Keeps n newest blocks. Default: 0 - means no message storage at all.",
+
     }
 }
 
@@ -829,6 +835,7 @@ struct Config {
     ipc: Option<Ipc>,
     secretstore: Option<SecretStore>,
     mining: Option<Mining>,
+    hbbft: Option<Hbbft>,
     footprint: Option<Footprint>,
     snapshots: Option<Snapshots>,
     misc: Option<Misc>,
@@ -995,6 +1002,13 @@ struct Mining {
     infinite_pending_block: Option<bool>,
     max_round_blocks_to_import: Option<usize>,
     new_transactions_stats_period: Option<u64>,
+}
+
+// hbbft consensus specific options
+#[derive(Default, Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Hbbft {
+    blocks_to_keep_on_disk: Option<u64>,
 }
 
 #[derive(Default, Debug, PartialEq, Deserialize)]

--- a/bin/oe/cli/mod.rs
+++ b/bin/oe/cli/mod.rs
@@ -814,12 +814,6 @@ usage! {
             ARG arg_snapshot_threads: (Option<usize>) = None, or |c: &Config| c.snapshots.as_ref()?.processing_threads,
             "--snapshot-threads=[NUM]",
             "Enables multiple threads for snapshots creation.",
-
-        ["Hbbft Options "]
-            ARG blocks_to_keep_on_disk: (Option<u64>) = Some(0), or |c: &Config| c.hbbft.as_ref()?.blocks_to_keep_on_disk,
-            "--blocks-to-keep-on-disk=[NUM]",
-            "Configures hbbft messages that should be kept on disk. Keeps n newest blocks. Default: 0 - means no message storage at all.",
-
     }
 }
 
@@ -835,7 +829,6 @@ struct Config {
     ipc: Option<Ipc>,
     secretstore: Option<SecretStore>,
     mining: Option<Mining>,
-    hbbft: Option<Hbbft>,
     footprint: Option<Footprint>,
     snapshots: Option<Snapshots>,
     misc: Option<Misc>,
@@ -1002,13 +995,6 @@ struct Mining {
     infinite_pending_block: Option<bool>,
     max_round_blocks_to_import: Option<usize>,
     new_transactions_stats_period: Option<u64>,
-}
-
-// hbbft consensus specific options
-#[derive(Default, Debug, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct Hbbft {
-    blocks_to_keep_on_disk: Option<u64>,
 }
 
 #[derive(Default, Debug, PartialEq, Deserialize)]

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -210,7 +210,9 @@ impl HoneyBadgerBFT {
             signer: Arc::new(RwLock::new(None)),
             machine,
             hbbft_state: RwLock::new(HbbftState::new()),
-            hbbft_message_dispatcher: RwLock::new(HbbftMessageDispatcher::new()),
+            hbbft_message_dispatcher: RwLock::new(HbbftMessageDispatcher::new(
+                params.blocks_to_keep_on_disk.unwrap_or(0),
+            )),
             sealing: RwLock::new(BTreeMap::new()),
             params,
             message_counter: RwLock::new(0),

--- a/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_message_memorium.rs
@@ -44,6 +44,7 @@ pub(crate) struct HbbftMessageMemorium {
     // */
     // agreements: BTreeMap<u64, Vec<(NodeId, NodeId, HbMessage)>>,
     message_tracking_id: u64,
+
     config_blocks_to_keep_on_disk: u64,
     last_block_deleted_from_disk: u64,
     dispatched_messages: VecDeque<HbMessage>,
@@ -109,7 +110,7 @@ impl HbbftMessageMemorium {
             // decryption_shares: BTreeMap::new(),
             // agreements: BTreeMap::new(),
             message_tracking_id: 0,
-            config_blocks_to_keep_on_disk: 200,
+            config_blocks_to_keep_on_disk: 0,
             last_block_deleted_from_disk: 0,
             dispatched_messages: VecDeque::new(),
             dispatched_seals: VecDeque::new(),
@@ -187,13 +188,14 @@ impl HbbftMessageMemorium {
     }
 
     fn work_message(&mut self) -> bool {
-        // warn!(target: "consensus", "working on hbbft messages: {} consensuns: {}", self.dispatched_messages.len(), self.dispatched_seals.len());
 
         if let Some(message) = self.dispatched_messages.pop_front() {
             let epoch = message.epoch();
+
+
+            
             match serde_json::to_string(&message) {
                 Ok(json_string) => {
-                    // debug!(target: "consensus", "{}", json_string);
                     self.on_message_string_received(json_string, epoch);
                 }
                 Err(e) => {

--- a/crates/ethjson/src/spec/hbbft.rs
+++ b/crates/ethjson/src/spec/hbbft.rs
@@ -49,6 +49,8 @@ pub struct HbbftParams {
     pub block_reward_contract_address: Option<Address>,
     /// Block reward skips at different blocks.
     pub block_reward_skips: Option<Vec<HbbftParamsSkipBlockReward>>,
+    /// Number of consensus messages to store on the disk. 0 means zero blocks get stored.
+    pub blocks_to_keep_on_disk: Option<u64>,
 }
 
 /// Hbbft engine config.


### PR DESCRIPTION
https://github.com/DMDcoin/openethereum-3.x/issues/17

example:
keep the latest received message for blocks on disk.
This can be used for debug, analysis and evidence.
```
"blocksToKeepOnDisk"": 100,
```