### PR TITLE
i101: refactored check for epoch change 

### DIFF
--- a/crates/ethcore/src/block.rs
+++ b/crates/ethcore/src/block.rs
@@ -390,10 +390,7 @@ impl<'x> OpenBlock<'x> {
                 .map_or_else(U256::zero, |r| r.gas_used),
         );
 
-        let result = LockedBlock { block: s.block };
-        s.engine.on_locked_block(&result);
-
-        Ok(result)
+        Ok(LockedBlock { block: s.block })
     }
 
     #[cfg(test)]

--- a/crates/ethcore/src/block.rs
+++ b/crates/ethcore/src/block.rs
@@ -391,7 +391,7 @@ impl<'x> OpenBlock<'x> {
         );
 
         let result = LockedBlock { block: s.block };
-        s.engine.on_locked_block(&result)?;
+        s.engine.on_locked_block(&result);
 
         Ok(result)
     }

--- a/crates/ethcore/src/block.rs
+++ b/crates/ethcore/src/block.rs
@@ -394,8 +394,6 @@ impl<'x> OpenBlock<'x> {
         s.engine.on_locked_block(&result)?;
 
         Ok(result)
-
-        
     }
 
     #[cfg(test)]

--- a/crates/ethcore/src/block.rs
+++ b/crates/ethcore/src/block.rs
@@ -391,8 +391,7 @@ impl<'x> OpenBlock<'x> {
         );
 
         let result = LockedBlock { block: s.block };
-
-        s.engine.on_block_closed(&result)?;
+        s.engine.on_locked_block(&result)?;
 
         Ok(result)
 

--- a/crates/ethcore/src/block.rs
+++ b/crates/ethcore/src/block.rs
@@ -390,7 +390,13 @@ impl<'x> OpenBlock<'x> {
                 .map_or_else(U256::zero, |r| r.gas_used),
         );
 
-        Ok(LockedBlock { block: s.block })
+        let result = LockedBlock { block: s.block };
+
+        s.engine.on_block_closed(&result)?;
+
+        Ok(result)
+
+        
     }
 
     #[cfg(test)]

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -3343,9 +3343,7 @@ impl ImportExportBlocks for Client {
                 Err(e) => {
                     return Err(format!("Cannot import block #{}: {:?}", number, e));
                 }
-                Ok(block_hash) => {
-                    self.engine.on_imported_block_hash(&block_hash);
-                }
+                Ok(_) => {}
             }
             Ok(())
         };

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -3343,7 +3343,7 @@ impl ImportExportBlocks for Client {
                     return Err(format!("Cannot import block #{}: {:?}", number, e));
                 }
                 Ok(block_hash) => {
-                    self.engine.on_imported_block_hash(block_hash);
+                    self.engine.on_imported_block_hash(&block_hash);
                 }
             }
             Ok(())

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -780,6 +780,7 @@ impl Importer {
         client.db.read().key_value().write_buffered(batch);
         // t_nb 9.12 commit changed to become current greatest by applying pending insertion updates (Sync point)
         chain.commit();
+        self.engine.on_chain_commit(&header.hash());
 
         // t_nb 9.13 check epoch end. Related only to AuRa and it seems light engine
         self.check_epoch_end(&header, &finalized, &chain, client);

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -3342,7 +3342,9 @@ impl ImportExportBlocks for Client {
                 Err(e) => {
                     return Err(format!("Cannot import block #{}: {:?}", number, e));
                 }
-                Ok(_) => {}
+                Ok(block_hash) => {
+                    self.engine.on_imported_block_hash(block_hash);
+                }
             }
             Ok(())
         };

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -985,7 +985,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn verify_local_seal(&self, _header: &Header) -> Result<(), Error> {
-        self.check_for_epoch_change();
+        // self.check_for_epoch_change();
         Ok(())
     }
 
@@ -1076,7 +1076,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         &self,
         block: &ExecutedBlock,
     ) -> Result<Vec<SignedTransaction>, Error> {
-        self.check_for_epoch_change();
+        // self.check_for_epoch_change();
         let _random_number = match self.random_numbers.read().get(&block.header.number()) {
             None => {
                 return Err(EngineError::Custom(
@@ -1112,7 +1112,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn on_transactions_imported(&self) {
-        self.check_for_epoch_change();
+        // self.check_for_epoch_change();
         if let Some(client) = self.client_arc() {
             if self.transaction_queue_and_time_thresholds_reached(&client) {
                 self.start_hbbft_epoch(client);
@@ -1121,7 +1121,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn handle_message(&self, message: &[u8], node_id: Option<H512>) -> Result<(), EngineError> {
-        self.check_for_epoch_change();
+        // self.check_for_epoch_change();
         let node_id = NodeId(node_id.ok_or(EngineError::UnexpectedMessage)?);
         match serde_json::from_slice(message) {
             Ok(Message::HoneyBadger(msg_idx, hb_msg)) => {
@@ -1173,7 +1173,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn on_close_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
-        self.check_for_epoch_change();
+        // self.check_for_epoch_change();
 
         if let Some(address) = self.params.block_reward_contract_address {
             // only if no block reward skips are defined for this block.

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1191,7 +1191,22 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         Ok(())
     }
 
-    fn on_imported_block_hash(&self, block_hash: &H256) {
+    // fn on_imported_block_hash(&self, block_hash: &H256) {
+    //     if let Some(client) = self.client_arc() {
+    //         if let None = self.hbbft_state.write().update_honeybadger(
+    //             client,
+    //             &self.signer,
+    //             BlockId::Hash(*block_hash),
+    //             false,
+    //         ) {
+    //             error!(target: "engine", "could not update honey badger after importing block {block_hash}: update honeybadger failed");
+    //         }
+    //     } else {
+    //         error!(target: "engine", "could not update honey badger after importing the block {block_hash}: no client");
+    //     }
+    // }
+
+    fn on_chain_commit(&self, block_hash: &H256) {
         if let Some(client) = self.client_arc() {
             if let None = self.hbbft_state.write().update_honeybadger(
                 client,

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -839,19 +839,6 @@ impl HoneyBadgerBFT {
         }
     }
 
-    fn check_for_epoch_change(&self) -> Option<()> {
-        let client = self.client_arc()?;
-        if let None = self.hbbft_state.write().update_honeybadger(
-            client,
-            &self.signer,
-            BlockId::Latest,
-            false,
-        ) {
-            error!(target: "consensus", "Fatal: Updating Honey Badger instance failed!");
-        }
-        Some(())
-    }
-
     fn is_syncing(&self, client: &Arc<dyn EngineClient>) -> bool {
         match client.as_full_client() {
             Some(full_client) => full_client.is_major_syncing(),
@@ -986,7 +973,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn verify_local_seal(&self, _header: &Header) -> Result<(), Error> {
-        // self.check_for_epoch_change();
         Ok(())
     }
 
@@ -1077,7 +1063,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         &self,
         block: &ExecutedBlock,
     ) -> Result<Vec<SignedTransaction>, Error> {
-        // self.check_for_epoch_change();
+
         let _random_number = match self.random_numbers.read().get(&block.header.number()) {
             None => {
                 return Err(EngineError::Custom(
@@ -1113,7 +1099,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn on_transactions_imported(&self) {
-        // self.check_for_epoch_change();
         if let Some(client) = self.client_arc() {
             if self.transaction_queue_and_time_thresholds_reached(&client) {
                 self.start_hbbft_epoch(client);
@@ -1122,7 +1107,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn handle_message(&self, message: &[u8], node_id: Option<H512>) -> Result<(), EngineError> {
-        // self.check_for_epoch_change();
         let node_id = NodeId(node_id.ok_or(EngineError::UnexpectedMessage)?);
         match serde_json::from_slice(message) {
             Ok(Message::HoneyBadger(msg_idx, hb_msg)) => {
@@ -1174,8 +1158,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn on_close_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
-        // self.check_for_epoch_change();
-
         if let Some(address) = self.params.block_reward_contract_address {
             // only if no block reward skips are defined for this block.
             let header_number = block.header.number();

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1208,6 +1208,21 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 
         Ok(())
     }
+
+    fn on_locked_block(&self, block: &crate::block::LockedBlock) {
+        if let Some(client) = self.client_arc() {
+            if let None = self.hbbft_state.write().update_honeybadger(
+                client,
+                &self.signer,
+                BlockId::Number(block.header.number()),
+                false,
+            ) {
+                error!(target: "engine", "could not update honey badger after locking the block: update honeybadger failed");
+            }
+        } else {
+            error!(target: "engine", "could not update honey badger after locking the block: no client");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1063,7 +1063,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         &self,
         block: &ExecutedBlock,
     ) -> Result<Vec<SignedTransaction>, Error> {
-
         let _random_number = match self.random_numbers.read().get(&block.header.number()) {
             None => {
                 return Err(EngineError::Custom(

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1210,6 +1210,8 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
     }
 
     fn on_locked_block(&self, block: &crate::block::LockedBlock) {
+
+        error!(target: "engine", "on_locked_block called {} {}", block.header.number(), block.header.hash());
         if let Some(client) = self.client_arc() {
             if let None = self.hbbft_state.write().update_honeybadger(
                 client,
@@ -1217,10 +1219,25 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
                 BlockId::Number(block.header.number()),
                 false,
             ) {
-                error!(target: "engine", "could not update honey badger after locking the block: update honeybadger failed");
+                error!(target: "engine", "could not update honey badger after locking the block: update honeybadger failed {} {} ", block.header.number(), block.header.hash());
             }
         } else {
-            error!(target: "engine", "could not update honey badger after locking the block: no client");
+            error!(target: "engine", "could not update honey badger after locking the block: no client {} {}", block.header.number(), block.header.hash());
+        }
+    }
+
+    fn on_imported_block_hash(&self, block_hash: H256) {
+        if let Some(client) = self.client_arc() {
+            if let None = self.hbbft_state.write().update_honeybadger(
+                client,
+                &self.signer,
+                BlockId::Hash(block_hash),
+                false,
+            ) {
+                error!(target: "engine", "could not update honey badger after importing block {block_hash}: update honeybadger failed");
+            }
+        } else {
+            error!(target: "engine", "could not update honey badger after importing the block {block_hash}: no client");
         }
     }
 }

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -441,6 +441,7 @@ impl HoneyBadgerBFT {
                 }
             };
             self.process_seal_step(client, step, block_num, network_info);
+            self.on_imported_block_hash(&hash);
         } else {
             error!(target: "consensus", "Could not create pending block for hbbft epoch {}: ", batch.epoch);
         }
@@ -1209,29 +1210,12 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         Ok(())
     }
 
-    fn on_locked_block(&self, block: &crate::block::LockedBlock) {
-
-        error!(target: "engine", "on_locked_block called {} {}", block.header.number(), block.header.hash());
+    fn on_imported_block_hash(&self, block_hash: &H256) {
         if let Some(client) = self.client_arc() {
             if let None = self.hbbft_state.write().update_honeybadger(
                 client,
                 &self.signer,
-                BlockId::Number(block.header.number()),
-                false,
-            ) {
-                error!(target: "engine", "could not update honey badger after locking the block: update honeybadger failed {} {} ", block.header.number(), block.header.hash());
-            }
-        } else {
-            error!(target: "engine", "could not update honey badger after locking the block: no client {} {}", block.header.number(), block.header.hash());
-        }
-    }
-
-    fn on_imported_block_hash(&self, block_hash: H256) {
-        if let Some(client) = self.client_arc() {
-            if let None = self.hbbft_state.write().update_honeybadger(
-                client,
-                &self.signer,
-                BlockId::Hash(block_hash),
+                BlockId::Hash(*block_hash),
                 false,
             ) {
                 error!(target: "engine", "could not update honey badger after importing block {block_hash}: update honeybadger failed");

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -441,7 +441,6 @@ impl HoneyBadgerBFT {
                 }
             };
             self.process_seal_step(client, step, block_num, network_info);
-            self.on_imported_block_hash(&hash);
         } else {
             error!(target: "consensus", "Could not create pending block for hbbft epoch {}: ", batch.epoch);
         }
@@ -1190,21 +1189,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 
         Ok(())
     }
-
-    // fn on_imported_block_hash(&self, block_hash: &H256) {
-    //     if let Some(client) = self.client_arc() {
-    //         if let None = self.hbbft_state.write().update_honeybadger(
-    //             client,
-    //             &self.signer,
-    //             BlockId::Hash(*block_hash),
-    //             false,
-    //         ) {
-    //             error!(target: "engine", "could not update honey badger after importing block {block_hash}: update honeybadger failed");
-    //         }
-    //     } else {
-    //         error!(target: "engine", "could not update honey badger after importing the block {block_hash}: no client");
-    //     }
-    // }
 
     fn on_chain_commit(&self, block_hash: &H256) {
         if let Some(client) = self.client_arc() {

--- a/crates/ethcore/src/engines/hbbft/hbbft_state.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_state.rs
@@ -57,7 +57,15 @@ impl HbbftState {
         block_id: BlockId,
         force: bool,
     ) -> Option<()> {
-        let target_posdao_epoch = get_posdao_epoch(&*client, block_id).ok()?.low_u64();
+        let target_posdao_epoch: u64;
+        match get_posdao_epoch(&*client, block_id) {
+            Ok(value) => target_posdao_epoch = value.low_u64(),
+            Err(error) => {
+                error!(target: "engine", "error calling get_posdao_epoch for block {:?}: {:?}", block_id, error);
+                return None;
+            }
+        }
+
         if !force && self.current_posdao_epoch == target_posdao_epoch {
             // hbbft state is already up to date.
             // @todo Return proper error codes.

--- a/crates/ethcore/src/engines/hbbft/hbbft_state.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_state.rs
@@ -165,7 +165,7 @@ impl HbbftState {
     fn skip_to_current_epoch(
         &mut self,
         client: Arc<dyn EngineClient>,
-        signer: &Arc<RwLock<Option<Box<dyn EngineSigner>>>>,
+        _signer: &Arc<RwLock<Option<Box<dyn EngineSigner>>>>,
     ) -> Option<()> {
         // Ensure we evaluate at the same block # in the entire upward call graph to avoid inconsistent state.
         let latest_block_number = client.block_number(BlockId::Latest)?;
@@ -175,13 +175,6 @@ impl HbbftState {
 
         // we asume that honey badger instance is up to date here.
         // it has to be updated after closing each block.
-
-        self.update_honeybadger(
-            client.clone(),
-            signer,
-            BlockId::Number(latest_block_number),
-            false,
-        );
 
         // If honey_badger is None we are not a validator, nothing to do.
         let honey_badger = self.honey_badger.as_mut()?;

--- a/crates/ethcore/src/engines/hbbft/hbbft_state.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_state.rs
@@ -164,12 +164,16 @@ impl HbbftState {
 
         // Update honey_badger *before* trying to use it to make sure we use the data
         // structures matching the current epoch.
-        self.update_honeybadger(
-            client.clone(),
-            signer,
-            BlockId::Number(latest_block_number),
-            false,
-        );
+
+        // we asume that honey badger instance is up to date here.
+        // it has to be updated after closing each block.
+
+        // self.update_honeybadger(
+        //     client.clone(),
+        //     signer,
+        //     BlockId::Number(latest_block_number),
+        //     false,
+        // );
 
         // If honey_badger is None we are not a validator, nothing to do.
         let honey_badger = self.honey_badger.as_mut()?;

--- a/crates/ethcore/src/engines/hbbft/hbbft_state.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_state.rs
@@ -176,12 +176,12 @@ impl HbbftState {
         // we asume that honey badger instance is up to date here.
         // it has to be updated after closing each block.
 
-        // self.update_honeybadger(
-        //     client.clone(),
-        //     signer,
-        //     BlockId::Number(latest_block_number),
-        //     false,
-        // );
+        self.update_honeybadger(
+            client.clone(),
+            signer,
+            BlockId::Number(latest_block_number),
+            false,
+        );
 
         // If honey_badger is None we are not a validator, nothing to do.
         let honey_badger = self.honey_badger.as_mut()?;

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -355,6 +355,9 @@ pub trait Engine<M: Machine>: Sync + Send {
     /// Block was closed an locked.
     fn on_locked_block(&self, _block: &LockedBlock) {}
 
+    /// Block was imported.
+    fn on_imported_block_hash(&self, _block_hash: H256) {} 
+
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {
         Ok(())

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -353,9 +353,7 @@ pub trait Engine<M: Machine>: Sync + Send {
     }
 
     /// Block was closed an locked.
-    fn on_locked_block(&self, _block: &LockedBlock) -> Result<(), M::Error> {
-        Ok(())
-    }
+    fn on_locked_block(&self, _block: &LockedBlock) {}
 
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -336,6 +336,9 @@ pub trait Engine<M: Machine>: Sync + Send {
     /// New transactions were imported to the transaction queue
     fn on_transactions_imported(&self) {}
 
+    /// sealed block got commited to the blockchain  
+    fn on_chain_commit(&self, _hash: &H256) {}
+
     /// Block transformation functions, before the transactions.
     /// `epoch_begin` set to true if this block kicks off an epoch.
     fn on_new_block(

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -353,8 +353,7 @@ pub trait Engine<M: Machine>: Sync + Send {
     }
 
     /// Block was closed an locked.
-    fn on_locked_block(&self, _block: & LockedBlock)
-    -> Result<(), M::Error> {
+    fn on_locked_block(&self, _block: &LockedBlock) -> Result<(), M::Error> {
         Ok(())
     }
 

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -27,6 +27,8 @@ mod validator_set;
 pub mod block_reward;
 pub mod signer;
 
+use crate::block::LockedBlock;
+
 pub use self::{
     authority_round::AuthorityRound,
     basic_authority::BasicAuthority,
@@ -349,6 +351,8 @@ pub trait Engine<M: Machine>: Sync + Send {
     fn on_close_block(&self, _block: &mut ExecutedBlock) -> Result<(), M::Error> {
         Ok(())
     }
+
+    
 
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -352,11 +352,8 @@ pub trait Engine<M: Machine>: Sync + Send {
         Ok(())
     }
 
-    /// Block was closed an locked.
-    fn on_locked_block(&self, _block: &LockedBlock) {}
-
     /// Block was imported.
-    fn on_imported_block_hash(&self, _block_hash: H256) {} 
+    fn on_imported_block_hash(&self, _block_hash: &H256) {}
 
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -352,7 +352,11 @@ pub trait Engine<M: Machine>: Sync + Send {
         Ok(())
     }
 
-    
+    /// Block was closed an locked.
+    fn on_locked_block(&self, _block: & LockedBlock)
+    -> Result<(), M::Error> {
+        Ok(())
+    }
 
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {

--- a/crates/ethcore/src/engines/mod.rs
+++ b/crates/ethcore/src/engines/mod.rs
@@ -355,9 +355,6 @@ pub trait Engine<M: Machine>: Sync + Send {
         Ok(())
     }
 
-    /// Block was imported.
-    fn on_imported_block_hash(&self, _block_hash: &H256) {}
-
     /// Allow mutating the header during seal generation. Currently only used by Clique.
     fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {
         Ok(())


### PR DESCRIPTION
 refactored check for epoch change to only do 1 update on the thread that does the block inclusion.

The function  check_for_epoch_change was removed completely.
https://github.com/DMDcoin/openethereum-3.x/issues/101